### PR TITLE
wandb and e3nn-related bugfix

### DIFF
--- a/models/tensor_layers.py
+++ b/models/tensor_layers.py
@@ -127,7 +127,7 @@ def tp_scatter_simple(tp, fc_layer, node_attr, edge_index, edge_attr, edge_sh,
     """
     Perform TensorProduct + scatter operation, aka graph convolution.
 
-    This function is only for edge_groups == 1. For multiple edge groups, and for larger graphs,
+    This function is only for out_irrepss == 1. For multiple edge groups, and for larger graphs,
     use tp_scatter_multigroup instead.
     """
 
@@ -196,7 +196,7 @@ def tp_scatter_multigroup(tp: o3.TensorProduct, fc_layer: Union[nn.Module, nn.Mo
     edge_weight_is_indexable = hasattr(edge_weight, '__getitem__')
 
     out_nodes = out_nodes or node_attr.shape[0]
-    total_output_dim = sum([x.dim for x in tp.irreps_out])
+    total_output_dim = sum([x.dim for x in tp.out_irreps])
     final_out = torch.zeros((out_nodes, total_output_dim), device=_device, dtype=_dtype)
     div_factors = torch.zeros(out_nodes, device=_device, dtype=_dtype)
 

--- a/train.py
+++ b/train.py
@@ -214,7 +214,7 @@ def main_function():
 
     if args.wandb:
         wandb_args = {
-            'entity':'eac709-nyu',
+            'entity':args.entity,
             'settings':wandb.Settings(start_method="fork"),
             'project':args.project,
             'name':args.run_name,

--- a/train.py
+++ b/train.py
@@ -107,11 +107,19 @@ def train(args, model, optimizer, scheduler, ema_weights, train_loader, val_load
             ema_weights.restore(model.parameters())
 
         if args.wandb:
-            logs.update({'train_' + k: v for k, v in train_losses.items()})
-            logs.update({'val_' + k: v for k, v in val_losses.items()})
-            logs['current_lr'] = optimizer.param_groups[0]['lr']
-            wandb.log(logs, step=epoch + 1)
-
+            if args.DDP:
+                if args.local_rank==0:
+                    print("log wandb: rank 0")
+                    logs.update({'train_' + k: v for k, v in train_losses.items()})
+                    logs.update({'val_' + k: v for k, v in val_losses.items()})
+                    logs['current_lr'] = optimizer.param_groups[0]['lr']
+                    wandb.log(logs, step=epoch + 1)
+            else:
+                logs.update({'train_' + k: v for k, v in train_losses.items()})
+                logs.update({'val_' + k: v for k, v in val_losses.items()})
+                logs['current_lr'] = optimizer.param_groups[0]['lr']
+                wandb.log(logs, step=epoch + 1)
+                
         state_dict = model.module.state_dict() if device.type == 'cuda' and not (args.no_parallel or args.DDP) else model.state_dict()
         if args.inference_earlystop_metric in logs.keys() and \
                 (args.inference_earlystop_goal == 'min' and logs[args.inference_earlystop_metric] <= best_val_inference_value or
@@ -179,25 +187,6 @@ def main_function():
     if args.cudnn_benchmark:
         torch.backends.cudnn.benchmark = True
 
-    if args.wandb:
-        wandb_args = {
-            'entity':'eac709-nyu',
-            'settings':wandb.Settings(start_method="fork"),
-            'project':args.project,
-            'name':args.run_name,
-            'config':args,
-        }
-        if args.DDP:
-            print("DDP wandb group")
-            wandb_args.update({'group':"DDP"})
-        if args.restart_dir: 
-            print("resume wandb run")
-            wandb_args.update({
-                "id":args.wandb_id,
-                "resume":"must"
-            })
-        wandb.init(**wandb_args)
-
     local_rank=None
     if args.DDP:
         world_size    = int(os.environ["WORLD_SIZE"])
@@ -219,8 +208,35 @@ def main_function():
         device = torch.device(f'cuda:{local_rank}')
         args.world_size=world_size
         args.rank=rank
+        args.local_rank=local_rank
     else:
         device = torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')
+
+    if args.wandb:
+        wandb_args = {
+            'entity':'eac709-nyu',
+            'settings':wandb.Settings(start_method="fork"),
+            'project':args.project,
+            'name':args.run_name,
+            'config':args,
+        }
+        if args.restart_dir: 
+            print(f"resume wandb run: {args.wandb_id}")
+            wandb_args.update({
+                "id":args.wandb_id,
+                "resume":"must"
+            })
+        if args.DDP:
+            ## wandb has issues spawning multiple runs when doing DDP..resolve this by only tracking rank0
+            # wandb_args.update({
+            #     'group':"DDP",
+            #     'job_type':"worker"
+            # })
+            if args.local_rank==0:
+                print("Log DDP only from rank0")
+                wandb.init(**wandb_args)
+        else:
+            wandb.init(**wandb_args)
 
     # construct loader
     t_to_sigma = partial(t_to_sigma_compl, args=args)
@@ -252,7 +268,7 @@ def main_function():
             dict = torch.load(f'{args.restart_dir}/{args.restart_ckpt}.pt', map_location=torch.device('cpu'))
             if args.restart_lr is not None: dict['optimizer']['param_groups'][0]['lr'] = args.restart_lr
             optimizer.load_state_dict(dict['optimizer'])
-            model.module.load_state_dict(dict['model'], strict=True)
+            model.load_state_dict(dict['model'], strict=True)
             if hasattr(args, 'ema_rate'):
                 ema_weights.load_state_dict(dict['ema_weights'], device=device)
             print("Restarting from epoch", dict['epoch'])
@@ -261,7 +277,7 @@ def main_function():
         except Exception as e:
             print("Exception", e)
             dict = torch.load(f'{args.restart_dir}/best_model.pt', map_location=torch.device('cpu'))
-            model.module.load_state_dict(dict, strict=True)
+            model.load_state_dict(dict, strict=True)
             print("Due to exception had to take the best epoch and no optimiser")
     elif args.pretrain_dir:
         dict = torch.load(f'{args.pretrain_dir}/{args.pretrain_ckpt}.pt', map_location=torch.device('cpu'))
@@ -272,7 +288,11 @@ def main_function():
     print('Model with', numel, 'parameters')
 
     if args.wandb:
-        wandb.log({'numel': numel})
+        if args.DDP:
+            if args.local_rank==0:
+                wandb.log({'numel': numel})
+        else:
+            wandb.log({'numel': numel})
 
     run_dir = os.path.join(args.log_dir, args.run_name)
     args.device = device
@@ -297,7 +317,8 @@ def main_function():
 
     if args.DDP:
         dist.destroy_process_group()
-        wandb.finish()
+        if local_rank==0:
+            wandb.finish()
 
 def setup(rank, world_size):
     # initialize the process group

--- a/utils/parsing.py
+++ b/utils/parsing.py
@@ -31,8 +31,9 @@ def parse_train_args():
     parser.add_argument('--inference_earlystop_metric', type=str, default='valinf_min_rmsds_lt2', help='This is the metric that is addionally used when val_inference_freq is not None')
     parser.add_argument('--inference_secondary_metric', type=str, default=None, help='')
     parser.add_argument('--inference_earlystop_goal', type=str, default='max', help='Whether to maximize or minimize metric')
-    parser.add_argument('--wandb', action='store_true', default=False, help='')
+    parser.add_argument('--wandb', action='store_true', default=False, help='Flag for logging runs on wandb')
     parser.add_argument('--project', type=str, default='diffdock', help='')
+    parser.add_argument('--entity', type=str, default='eac709-nyu', help='wandb account')
     parser.add_argument('--run_name', type=str, default='', help='')
     parser.add_argument('--wandb_id', type=str, default='', help='wandb restart id')
     parser.add_argument('--cudnn_benchmark', action='store_true', default=False, help='CUDA optimization parameter for faster training')
@@ -41,6 +42,7 @@ def parse_train_args():
     parser.add_argument('--pin_memory', action='store_true', default=False, help='pin_memory arg of dataloader')
     parser.add_argument('--dataloader_drop_last', action='store_true', default=False, help='drop_last arg of dataloader')
     parser.add_argument('--double_val', action='store_true', default=False, help='')
+    parser.add_argument('--rerun_val', action='store_true', default=False, help='Rerun complexes from the training set as a validation set to debug')
     parser.add_argument('--combined_training', action='store_true', default=False, help='')
 
     # Training arguments


### PR DESCRIPTION
to use wandb add the
`-entity`, `-project`,  and `-name` flags to the config file
to restart a run with wandb, pass in the run-id to `wandb_id`(and the associated directory with the last checkpoint to `restart_dir`)